### PR TITLE
bugfix: обновление токенов видеоархива

### DIFF
--- a/src/ui/src/app/shared/interceptors/shikivideos-requests.interceptor.ts
+++ b/src/ui/src/app/shared/interceptors/shikivideos-requests.interceptor.ts
@@ -49,6 +49,8 @@ export class ShikivideosRequestsInterceptor implements HttpInterceptor {
         .pipe(
           catchError((err: HttpErrorResponse) => {
 
+            // Update shikimori token and retry
+            // or update it with shikivideos token and retry
             if (err.status === 403) {
               return this.auth.shikimoriSync()
                 .pipe(
@@ -72,6 +74,7 @@ export class ShikivideosRequestsInterceptor implements HttpInterceptor {
                 );
             }
 
+            // Show notification, update shikivideos token and retry
             if (err.status === 401 && req.method === 'POST') {
               this._showWarningNotification();
 

--- a/src/ui/src/app/shared/interceptors/shikivideos-requests.interceptor.ts
+++ b/src/ui/src/app/shared/interceptors/shikivideos-requests.interceptor.ts
@@ -1,4 +1,4 @@
-import {Observable, throwError} from 'rxjs';
+import {EMPTY, Observable, throwError} from 'rxjs';
 import {HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {SmarthardNet} from '../../types/smarthard-net';
 import {AuthService} from '../../services/auth/auth.service';
@@ -64,10 +64,11 @@ export class ShikivideosRequestsInterceptor implements HttpInterceptor {
                 );
             }
 
+            // Forcefully update shikivideos token and drop previous request
             if (err.status === 401 && req.params.get('grant_type') === 'refresh_token') {
               return this.auth.shikivideosSync(true)
                 .pipe(
-                  exhaustMap(() => next.handle(req))
+                  exhaustMap(() => EMPTY)
                 );
             }
 

--- a/src/ui/src/app/shared/interceptors/shikivideos-requests.interceptor.ts
+++ b/src/ui/src/app/shared/interceptors/shikivideos-requests.interceptor.ts
@@ -74,12 +74,15 @@ export class ShikivideosRequestsInterceptor implements HttpInterceptor {
                 );
             }
 
-            // Show notification, update shikivideos token and retry
+            // Update shikivideos token and retry
+            // Show notification on error
             if (err.status === 401 && req.method === 'POST') {
-              this._showWarningNotification();
-
               return this.auth.shikivideosSync()
                 .pipe(
+                  catchError(() => {
+                    this._showWarningNotification();
+                    return EMPTY;
+                  }),
                   switchMap((token) => {
                     req = this._appendHeaders(req, token);
                     return next.handle(req);


### PR DESCRIPTION
Обновление токенов для главного архива происходило неправильно, из-за чего нужно было нажимать на кнопку обновления несколько раз. Автоматическое обновление токенов так же проходило с ошибкой. Теперь это исправлено.